### PR TITLE
Fix systemd unit and udev rule files install location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DIST_DOM0 ?= fc13
 
 LIBDIR ?= /usr/lib64
 USRLIBDIR ?= /usr/lib
-SYSLIBDIR ?= /lib
+SYSLIBDIR ?= /usr/lib
 DATADIR ?= /usr/share
 PA_VER ?= $(shell pkg-config --modversion libpulse | cut -d "-" -f 1 || echo 0.0)
 

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -39,6 +39,7 @@ URL:            http://www.qubes-os.org
 %if 0%{?suse_version} == 1500 && 0%{?is_opensuse}
 BuildRequires:  libpulse-devel >= 0.9.21, libpulse-devel <= 13.0
 BuildRequires:  xorg-x11-devel
+BuildRequires:  xorg-x11-server-sdk
 %else
 BuildRequires:  pulseaudio-libs-devel >= 0.9.21, pulseaudio-libs-devel <= 13.0
 BuildRequires:  xorg-x11-server-devel
@@ -79,6 +80,7 @@ Requires:       xorg-x11-server-Xephyr
 Requires:       python%{python3_pkgversion}-xcffib
 Requires:       xorg-x11-utils
 %endif
+Requires:       systemd
 Requires:       qubes-core-vm >= 3.0.14
 Requires:       qubes-libvchan-@BACKEND_VMM@
 # qubesdb-read --wait option

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -51,6 +51,7 @@ BuildRequires:  libXdamage-devel
 BuildRequires:  libXt-devel
 BuildRequires:  libtool-ltdl-devel
 BuildRequires:  pam-devel
+BuildRequires:  systemd
 BuildRequires:  qubes-libvchan-@BACKEND_VMM@-devel
 BuildRequires:  qubes-gui-common-devel >= 4.1.0
 BuildRequires:  qubes-db-devel
@@ -80,7 +81,6 @@ Requires:       xorg-x11-server-Xephyr
 Requires:       python%{python3_pkgversion}-xcffib
 Requires:       xorg-x11-utils
 %endif
-Requires:       systemd
 Requires:       qubes-core-vm >= 3.0.14
 Requires:       qubes-libvchan-@BACKEND_VMM@
 # qubesdb-read --wait option

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -183,8 +183,8 @@ rm -f %{name}-%{version}
 /etc/qubes-rpc/qubes.SetMonitorLayout
 /etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
 %config /etc/sysconfig/desktop
-/lib/systemd/system/qubes-gui-agent.service
-/lib/udev/rules.d/70-master-of-seat.rules
+%{_unitdir}/qubes-gui-agent.service
+/usr/lib/udev/rules.d/70-master-of-seat.rules
 /usr/lib/tmpfiles.d/qubes-session.conf
 /usr/lib/sysctl.d/30-qubes-gui-agent.conf
 /usr/lib/qubes/qubes-gui-agent-pre.sh


### PR DESCRIPTION
Unlike on Fedora-like systems, on SUSE /lib and /usr/lib are not same
so make sure to install files into correct location.